### PR TITLE
XCPNG-2818: Update to 2.1.0 release from xenserver

### DIFF
--- a/SOURCES/xenserver-status-report.tar.gz
+++ b/SOURCES/xenserver-status-report.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ce6aae8cfd68bed7567dcdeac99d5bf16d80764692e416ae647c269789e806e
-size 95860
+oid sha256:bfd56795fb9dc07f979b8173e6a929251e13ed56452413d017a1d087e50b914c
+size 95553

--- a/SPECS/xenserver-status-report.spec
+++ b/SPECS/xenserver-status-report.spec
@@ -1,9 +1,9 @@
-%global package_speccommit 85ec815ee602854c406f89d067db620bc52b8c12
-%global package_srccommit v2.0.15
+%global package_speccommit 55d6972c9d145d8c0b8c51709fa209c6f29909dd
+%global package_srccommit v2.1.0
 
 Summary:        A program that generates status reports for a XenServer host
 Name:           xenserver-status-report
-Version: 2.0.15
+Version: 2.1.0
 Release: 1%{?xsrel}%{?dist}
 License:        GPLv2+
 # Yes this is a very long line but it must remain as one line so that the koji tools can work on it.
@@ -12,56 +12,21 @@ BuildArch:      noarch
 %if 0%{?xenserver} < 9
 BuildRequires:  help2man
 %endif
-BuildRequires:  python-defusedxml
+BuildRequires:  python3-defusedxml
 # Same code is used for XS8/python2 and XS9/python3
 # we disable the shebang check here
 %global __brp_mangle_shebangs %nil
 
-# Keep in sync with the External Programs list.
 Requires:       acpica-tools
+%if 0%{?xenserver} < 9
 Requires:       arptables
-Requires:       biosdevname
-Requires:       bridge-utils
-Requires:       chrony
-Requires:       coreutils
-Requires:       device-mapper
-Requires:       device-mapper-multipath
-Requires:       dmidecode
 Requires:       ebtables
-Requires:       efibootmgr
-Requires:       ethtool
-%if 0%{?xenserver} < 9
-Requires:       fcoe-utils
 %endif
-Requires:       gzip
 Requires:       hdparm
-Requires:       iproute
 Requires:       iproute-tc
-Requires:       iptables
-Requires:       iscsi-initiator-utils
-Requires:       kmod
-Requires:       kpatch
-%if 0%{?xenserver} < 9
-Requires:       lldpad
-%endif
-Requires:       lvm2
-Requires:       mdadm
-Requires:       openvswitch
-Requires:       pciutils
-Requires:       procps-ng
-Requires:       python-defusedxml
-# For creating '/usr/bin/python' symlink to python3
-%if 0%{?xenserver} >= 9
-Requires:       python-unversioned-command
-%endif
-Requires:       sg3_utils
-Requires:       systemd
-Requires:       util-linux
+Requires:       python3-defusedxml
 Requires:       xapi-core
-Requires:       xapi-xe
 Requires:       xen-dom0-tools
-Requires:       xenopsd-xc
-Requires:       xen-tools
 
 %define bin0_name xen-bugtool
 
@@ -106,6 +71,22 @@ ln %{buildroot}/%{_mandir}/man1/%{bin0_name}.1 \
 %endif
 
 %changelog
+* Wed Nov 26 2025 Ross Lagerwall <ross.lagerwall@citrix.com> - 2.1.0-1
+- CP-309293: Remove most dependencies on external programs
+- Switch the Python shebang to use Python3
+- Add missing b to binary string
+- Ensure we collect system logs
+
+* Fri Aug 08 2025 Bengang Yuan <bengang.yuan@cloud.com> - 2.0.18-1
+- Revert "Merge pull request #138 from stephenchengCloud/private/stephenche/CP-51925"
+- CP-308824: collect nft and firewall-cmd output
+
+* Fri Jul 25 2025 Stephen Cheng <stephen.cheng@cloud.com> - 2.0.17-1
+- CP-51925: Remove fcoe from bug-tool
+
+* Wed Jul 09 2025 Chunjie Zhu <chunjie.zhu@cloud.com> - 2.0.16-1
+- CP-308325: add driver multi version info dump data
+
 * Mon Jun 09 2025 Mark Syms <mark.syms@cloud.com> - 2.0.15-1
 - CP-308256: gather SR sqlite3-metadata.db files
 


### PR DESCRIPTION
#### Context & Motivation

This is a new version from xenserver, it's a foundational update which switches to python 3, and adds support for future firewalls.

#### Release Target

8.3-next+1 (Samuel: :heavy_check_mark: )

---

### Release Notes and Documentation

#### Explain the change to users
This is a foundational update, no change in behaviour should be observed by the user, and because of this, doesn't need to be mentioned in the changelog.

#### Attention points

Users shouldn't need to pay special attention when updating

#### Documentation update needed

- [x] No

### Testing and regression avoidance

#### What tests have you performed?

I've run the update to the newest version to see what packages can be autoremoved after the fact. This is because there are many dependencies being removed.

The end result is that python2-defusedxml is not needed anymore, this is because python3-defusedxml is not required.

On top of this, I collected a bugtool using `xe`, which did not bring any significant changes (`xe host-get-system-status uuid=... fiename=bugtool.tar.bz2`), this created a bugtool with the usual files.

To understand better if there are any significant changes, I ran the tool directly:

```
# /usr/sbin/xen-bugtool --entries= --yestoall --output=tar.bz2
Warning: '--yestoall' argument provided, will not prompt for individual files.

This application will collate the Xen dmesg output, details of the
hardware configuration of your machine, information about the build of
Xen that you are using, plus, if you allow it, various logs.

The collated information will be saved as a .tar.bz2 for archiving or
sending to a Technical Support Representative.

The logs may contain private information, and if you are at all
worried about that, you should exit now, or you should explicitly
exclude those logs from the archive.


[06/08/26 15:50:48 BST]  Creating output file
[06/08/26 15:50:48 BST]  Running commands to collect data
[06/08/26 15:50:50 BST]  '/usr/sbin/nft  list ruleset' failed: [Errno 2] No such file or directory: '/usr/sbin/nft': '/usr/sbin/nft'
[06/08/26 15:50:50 BST]  '/usr/bin/firewall-cmd --list-all-zones' failed: [Errno 2] No such file or directory: '/usr/bin/firewall-cmd': '/usr/bin/firewall-cmd'
Omitting /dev/shm/metrics/xcp-rrdd-squeezed, size constraint of xcp-rrdd-plugins exceeded
Omitting /dev/shm/metrics/xcp-rrdd-xenpm, size constraint of xcp-rrdd-plugins exceeded
Omitting /dev/shm/metrics/xcp-rrdd-iostat, size constraint of xcp-rrdd-plugins exceeded
Writing tarball /var/opt/xen/bug-report/bug-report-20260608155048.tar.bz2 successful.
```

#### What manual tests should be performed after the build, and by whom?

The release manager might want to repeat the commands I ran to see if they are repeatable results.

#### What's covered by the xcp-ng-tests test suite?

There's nothing covering this, AFAIK

#### What tests have been or will be added to CI for this change? If none, explain why.

No tests are being added, this is an area with barely any changes, and easy to test. Adding tests would add churn to the already bottlenecked xcp-ng-tests

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [x] No
